### PR TITLE
Create Python repo template with CI

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,11 @@
+# Branch Protection Guidelines
+
+Configure the `main` branch with the following rules:
+
+- **Require pull request reviews** before merging.
+- **Require status checks to pass** for the CI workflow.
+- **Restrict direct pushes**, except for administrators who may bypass
+  the rules when necessary.
+
+These settings help ensure code quality and maintain a stable `main`
+branch while still allowing admins to perform emergency fixes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,118 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+
+# Pytest
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+ docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# PyCharm
+.idea/
+
+# VS Code
+.vscode/
+
+# OS-specific
+.DS_Store
+Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,118 +1,22 @@
-# Byte-compiled / optimized / DLL files
+# Byte-compiled / optimized files
 __pycache__/
 *.py[cod]
-*$py.class
 
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-*.egg-info/
-.installed.cfg
-*.egg
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-
-# Pytest
-.pytest_cache/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
- docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-.python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# dotenv
-.env
-
-# virtualenv
+# Virtual environment
 venv/
-ENV/
 
-# Spyder project settings
-.spyderproject
-.spyproject
+# Distribution artifacts
+build/
+dist/
+*.egg-info/
 
-# Rope project settings
-.ropeproject
+# Test and coverage reports
+.pytest_cache/
+htmlcov/
 
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-.dmypy.json
-
-# Pyre type checker
-.pyre/
-
-# PyCharm
+# IDE settings
+.vscode/
 .idea/
 
-# VS Code
-.vscode/
-
-# OS-specific
+# OS files
 .DS_Store
-Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-"# template-repo-python" 
+# Template Python Repository
+
+This repository provides a minimal Python project structure with
+a GitHub Actions workflow for automated testing. It can be used as a
+starting point for new Python projects.
+
+## Project Layout
+
+- `src/` - application source code
+- `tests/` - unit tests
+- `.github/workflows/` - CI configuration
+
+## Branch Protection
+
+Branch protection rules should require pull request reviews and passing
+status checks before merging to the `main` branch. Admins may be
+allowed to bypass these requirements where needed.
+
+## Getting Started
+
+1. Create a virtual environment:
+
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+
+2. Install dependencies (if any) and run tests:
+
+   ```bash
+   pip install -r requirements.txt  # optional
+   pytest
+   ```
+
+## License
+
+This project is provided as-is under the MIT License.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ starting point for new Python projects.
 - `src/` - application source code
 - `tests/` - unit tests
 - `.github/workflows/` - CI configuration
+- `pyproject.toml` - optional project metadata for packaging
 
 ## Branch Protection
 
@@ -31,6 +32,13 @@ allowed to bypass these requirements where needed.
    pip install -r requirements.txt  # optional
    pytest
    ```
+
+## pyproject.toml
+
+`pyproject.toml` stores build configuration and project metadata. It enables
+standard packaging with `setuptools` and can declare dependencies. You may
+remove it for simple scripts, but it is recommended if you intend to distribute
+the project as a package.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "template-package"
+version = "0.1.0"
+description = "A sample Python package"
+readme = "README.md"
+requires-python = ">=3.8"

--- a/src/template_package/__init__.py
+++ b/src/template_package/__init__.py
@@ -1,0 +1,3 @@
+"""Template package for Python projects."""
+
+__all__ = []

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,5 @@
+"""Basic sample test."""
+
+
+def test_true():
+    assert True


### PR DESCRIPTION
## Summary
- add Python package skeleton in `src/`
- configure GitHub Actions CI workflow
- provide branch protection guidelines
- document project usage in README
- include pyproject for packaging and gitignore
- add example test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874053c1ae8832daa10517c7ca32d98